### PR TITLE
[BB-5168] Add support for JWK Keysets

### DIFF
--- a/lti_consumer/lti_1p3/key_handlers.py
+++ b/lti_consumer/lti_1p3/key_handlers.py
@@ -68,8 +68,15 @@ class ToolKeyHandler:
         keyset = []
 
         if self.keyset_url:
-            # TODO: Improve support for keyset handling, handle errors.
-            keyset.extend(load_jwks_from_url(self.keyset_url))
+            try:
+                keys = load_jwks_from_url(self.keyset_url)
+            except Exception as err:
+                # Broad Exception is required here because jwkest raises
+                # an Exception object explicitly.
+                # Beware that many different scenarios are being handled
+                # as an invalid key when the JWK loading fails.
+                raise exceptions.NoSuitableKeys() from err
+            keyset.extend(keys)
 
         if self.public_key and kid:
             # Fill in key id of stored key.

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -282,6 +282,33 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             "prior to doing the launch request."
         ),
     )
+
+    lti_1p3_tool_key_mode = String(
+        display_name=_("Tool Public Key Mode"),
+        scope=Scope.settings,
+        values=[
+            {"display_name": "Public Key", "value": "public_key"},
+            {"display_name": "Keyset URL", "value": "keyset_url"},
+        ],
+        default="public_key",
+        help=_(
+            "Select how the tool's public key information will be specified."
+        ),
+    )
+    lti_1p3_tool_keyset_url = String(
+        display_name=_("Tool Keyset URL"),
+        default='',
+        scope=Scope.settings,
+        help=_(
+            "Enter the LTI 1.3 Tool's JWK keysets URL."
+            "<br />This link should retrieve a JSON file containing"
+            " public keys and signature algorithm information, so"
+            " that the LMS can check if the messages and launch"
+            " requests received have the signature from the tool."
+            "<br /><b>This is not required when doing LTI 1.3 Launches"
+            " without LTI Advantage nor Basic Outcomes requests.</b>"
+        ),
+    )
     lti_1p3_tool_public_key = String(
         display_name=_("Tool Public Key"),
         multiline_editor=True,
@@ -519,7 +546,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     editable_field_names = (
         'display_name', 'description',
         # LTI 1.3 variables
-        'lti_version', 'lti_1p3_launch_url', 'lti_1p3_oidc_url', 'lti_1p3_tool_public_key', 'lti_1p3_enable_nrps',
+        'lti_version', 'lti_1p3_launch_url', 'lti_1p3_oidc_url',
+        'lti_1p3_tool_key_mode', 'lti_1p3_tool_keyset_url', 'lti_1p3_tool_public_key',
+        'lti_1p3_enable_nrps',
         # LTI Advantage variables
         'lti_advantage_deep_linking_enabled', 'lti_advantage_deep_linking_launch_url',
         'lti_advantage_ags_mode',
@@ -572,6 +601,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             validation.add(ValidationMessage(ValidationMessage.ERROR, str(
                 _("Custom Parameters must be a list")
             )))
+
+        # keyset URL and public key are mutually exclusive
+        if data.lti_1p3_tool_key_mode == 'keyset_url':
+            data.lti_1p3_tool_public_key = ''
+        elif data.lti_1p3_tool_key_mode == 'public_key':
+            data.lti_1p3_tool_keyset_url = ''
 
     def get_settings(self):
         """

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -263,7 +263,7 @@ class LtiConfiguration(models.Model):
                 rsa_key_id=self.lti_1p3_private_key_id,
                 # LTI 1.3 Tool key/keyset url
                 tool_key=self.block.lti_1p3_tool_public_key,
-                tool_keyset_url=None,
+                tool_keyset_url=self.block.lti_1p3_tool_keyset_url,
             )
 
             # Check if enabled and setup LTI-AGS

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -14,6 +14,8 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
     const lti1P3FieldList = [
         "lti_1p3_launch_url",
         "lti_1p3_oidc_url",
+        "lti_1p3_tool_key_mode",
+        "lti_1p3_tool_keyset_url",
         "lti_1p3_tool_public_key",
         "lti_advantage_ags_mode",
         "lti_advantage_deep_linking_enabled",
@@ -72,12 +74,37 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
         });
     }
 
+    /**
+     * Only display the field appropriate for the selected key mode.
+     */
+    function toggleLtiToolKeyMode() {
+        const ltiKeyModeField = $(element).find('#xb-field-edit-lti_1p3_tool_key_mode');
+
+        // find the field containers
+        const ltiKeysetUrlField = $(element).find('[data-field-name=lti_1p3_tool_keyset_url]');
+        const ltiPublicKeyField = $(element).find('[data-field-name=lti_1p3_tool_public_key]');
+
+        const selectedKeyMode = ltiKeyModeField.children("option:selected").val();
+        if (selectedKeyMode === 'public_key') {
+            ltiKeysetUrlField.hide();
+            ltiPublicKeyField.show();
+        } else if (selectedKeyMode === 'keyset_url') {
+            ltiPublicKeyField.hide();
+            ltiKeysetUrlField.show();
+        }
+    }
+
     // Call once component is instanced to hide fields
     toggleLtiFields();
+    toggleLtiToolKeyMode();
 
     // Bind to onChange method of lti_version selector
     $(element).find('#xb-field-edit-lti_version').bind('change', function() {
         toggleLtiFields();
-     });
+    });
 
+    // Bind to onChange method of lti_1p3_tool_key_mode selector
+    $(element).find('#xb-field-edit-lti_1p3_tool_key_mode').bind('change', function() {
+        toggleLtiToolKeyMode();
+    });
 }

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -11,7 +11,7 @@ import ddt
 from Cryptodome.PublicKey import RSA
 from django.test.testcases import TestCase
 from django.utils import timezone
-from jwkest.jwk import RSAKey
+from jwkest.jwk import RSAKey, KEYS
 
 from lti_consumer.api import get_lti_1p3_launch_info
 from lti_consumer.exceptions import LtiError
@@ -425,6 +425,8 @@ class TestEditableFields(TestLtiConsumerXBlock):
                     'lti_version',
                     'lti_1p3_launch_url',
                     'lti_1p3_oidc_url',
+                    'lti_1p3_tool_key_mode',
+                    'lti_1p3_tool_keyset_url',
                     'lti_1p3_tool_public_key',
                     'lti_advantage_deep_linking_enabled',
                     'lti_advantage_deep_linking_launch_url',
@@ -1531,4 +1533,34 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
         request.content_type = 'application/x-www-form-urlencoded'
 
         response = self.xblock.lti_1p3_access_token(request)
+        self.assertEqual(response.status_code, 200)
+
+    @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
+    def test_access_token_using_keyset_url(self, load_jwks_from_url):
+        """
+        Test request with valid JWT, using the provider's keyset URL
+        instead of a public key.
+        """
+        self.xblock.lti_1p3_tool_public_key = ''
+        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
+        self.xblock.save()
+
+        jwt = create_jwt(self.key, {})
+        request = make_request(
+            urllib.parse.urlencode({
+                "grant_type": "client_credentials",
+                "client_assertion_type": "something",
+                "client_assertion": jwt,
+                "scope": "",
+            }),
+            'POST'
+        )
+        request.content_type = 'application/x-www-form-urlencoded'
+
+        jwks = KEYS()
+        jwks._keys = [self.key]  # pylint: disable=protected-access
+        load_jwks_from_url.return_value = jwks
+
+        response = self.xblock.lti_1p3_access_token(request)
+        load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
         self.assertEqual(response.status_code, 200)

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -2,6 +2,7 @@
 Unit tests for LtiConsumerXBlock
 """
 
+from contextlib import contextmanager
 import json
 import urllib.parse
 from datetime import timedelta
@@ -18,7 +19,7 @@ from lti_consumer.exceptions import LtiError
 from lti_consumer.lti_1p3.tests.utils import create_jwt
 from lti_consumer.lti_xblock import LtiConsumerXBlock, parse_handler_suffix
 from lti_consumer.tests.unit import test_utils
-from lti_consumer.tests.unit.test_utils import FAKE_USER_ID, make_request, make_xblock
+from lti_consumer.tests.unit.test_utils import FAKE_USER_ID, make_jwt_request, make_request, make_xblock
 
 HTML_PROBLEM_PROGRESS = '<div class="problem-progress">'
 HTML_ERROR_MESSAGE = '<h3 class="error_message">'
@@ -1459,17 +1460,7 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
         """
         Test request with invalid JWT.
         """
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": "invalid-jwt",
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
+        request = make_jwt_request("invalid-jwt")
         response = self.xblock.lti_1p3_access_token(request)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json_body, {'error': 'invalid_grant'})
@@ -1478,15 +1469,7 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
         """
         Test request with invalid grant.
         """
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "password",
-                "client_assertion_type": "something",
-                "client_assertion": "invalit-jwt",
-                "scope": "",
-            }),
-            'POST'
-        )
+        request = make_jwt_request("invalid-jwt", grant_type="password")
         request.content_type = 'application/x-www-form-urlencoded'
 
         response = self.xblock.lti_1p3_access_token(request)
@@ -1501,17 +1484,7 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
         self.xblock.save()
 
         jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
+        request = make_jwt_request(jwt)
         response = self.xblock.lti_1p3_access_token(request)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json_body, {'error': 'invalid_client'})
@@ -1521,165 +1494,90 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
         Test request with valid JWT.
         """
         jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
+        request = make_jwt_request(jwt)
         response = self.xblock.lti_1p3_access_token(request)
         self.assertEqual(response.status_code, 200)
 
-    @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
+
+class TestLti1p3AccessTokenJWK(TestCase):
+    """
+    Unit tests for LtiConsumerXBlock Access Token endpoint when using a
+    LTI 1.3 setup with JWK authentication.
+    """
+    def setUp(self):
+        super().setUp()
+        self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, {
+            'lti_version': 'lti_1p3',
+            'lti_1p3_launch_url': 'http://tool.example/launch',
+            'lti_1p3_oidc_url': 'http://tool.example/oidc',
+            'lti_1p3_tool_keyset_url': "http://tool.example/keyset",
+        })
+        self.xblock.location = 'block-v1:course+test+2020+type@problem+block@test'
+        self.xblock.save()
+
+        self.key = RSAKey(key=RSA.generate(2048), kid="1")
+
+        jwt = create_jwt(self.key, {})
+        self.request = make_jwt_request(jwt)
+
+    def make_keyset(self, keys):
+        """
+        Builds a keyset object with the given keys.
+        """
+        jwks = KEYS()
+        jwks._keys = keys  # pylint: disable=protected-access
+        return jwks
+
+    @patch("lti_consumer.lti_1p3.key_handlers.load_jwks_from_url")
     def test_access_token_using_keyset_url(self, load_jwks_from_url):
         """
-        Test request with valid JWT, using the provider's keyset URL instead of a public key.
+        Test request using the provider's keyset URL instead of a public key.
         """
-        self.xblock.lti_1p3_tool_public_key = ''
-        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
-        self.xblock.save()
-
-        jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
-        jwks = KEYS()
-        jwks._keys = [self.key]  # pylint: disable=protected-access
-        load_jwks_from_url.return_value = jwks
-
-        response = self.xblock.lti_1p3_access_token(request)
-        load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
+        load_jwks_from_url.return_value = self.make_keyset([self.key])
+        response = self.xblock.lti_1p3_access_token(self.request)
+        load_jwks_from_url.assert_called_once_with("http://tool.example/keyset")
         self.assertEqual(response.status_code, 200)
 
-    @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
+    @patch("lti_consumer.lti_1p3.key_handlers.load_jwks_from_url")
     def test_access_token_using_keyset_url_with_empty_keys(self, load_jwks_from_url):
         """
-        Test request with valid JWT, where the provider's keyset URL returns an empty list of keys.
+        Test request where the provider's keyset URL returns an empty list of keys.
         """
-        self.xblock.lti_1p3_tool_public_key = ''
-        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
-        self.xblock.save()
-
-        jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
-        jwks = KEYS()
-        jwks._keys = []  # pylint: disable=protected-access
-        load_jwks_from_url.return_value = jwks
-
-        response = self.xblock.lti_1p3_access_token(request)
-        load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
+        load_jwks_from_url.return_value = self.make_keyset([])
+        response = self.xblock.lti_1p3_access_token(self.request)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json_body, {'error': 'invalid_client'})
+        self.assertEqual(response.json_body, {"error": "invalid_client"})
 
-    @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
+    @patch("lti_consumer.lti_1p3.key_handlers.load_jwks_from_url")
     def test_access_token_using_keyset_url_with_wrong_keys(self, load_jwks_from_url):
         """
-        Test request with valid JWT, where the provider's keyset URL returns wrong keys.
+        Test request where the provider's keyset URL returns wrong keys.
         """
-        self.xblock.lti_1p3_tool_public_key = ''
-        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
-        self.xblock.save()
+        key = RSAKey(key=RSA.generate(2048), kid="2")
+        load_jwks_from_url.return_value = self.make_keyset([key])
+        response = self.xblock.lti_1p3_access_token(self.request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json_body, {"error": "invalid_client"})
 
-        jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
-        rsa_key = RSA.generate(2048)
-        key = RSAKey(key=rsa_key, kid='2')
-
-        jwks = KEYS()
-        jwks._keys = [key]  # pylint: disable=protected-access
-        load_jwks_from_url.return_value = jwks
-
-        response = self.xblock.lti_1p3_access_token(request)
-        load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
+    @patch("jwkest.jwk.request")
+    def test_access_token_using_keyset_url_that_fails(self, request):
+        """
+        Test request where the provider's keyset URL request fails.
+        """
+        request.side_effect = Exception("request fails")
+        response = self.xblock.lti_1p3_access_token(self.request)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json_body, {'error': 'invalid_client'})
 
-    @patch('jwkest.jwk.request')
-    def test_access_token_using_keyset_url_that_fails(self, request_func):
+    @patch("jwkest.jwk.request")
+    def test_access_token_using_keyset_url_with_invalid_contents(self, request):
         """
-        Test request with valid JWT, where the provider's keyset URL request fails.
+        Test request where the provider's keyset URL doesn't return valid JSON.
         """
-        self.xblock.lti_1p3_tool_public_key = ''
-        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
-        self.xblock.save()
-
-        jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
-        request_func.side_effect = Exception('request fails')
-
-        response = self.xblock.lti_1p3_access_token(request)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json_body, {'error': 'invalid_client'})
-
-    @patch('jwkest.jwk.request')
-    def test_access_token_using_keyset_url_with_invalid_contents(self, request_func):
-        """
-        Test request with valid JWT, where the provider's keyset URL doesn't return valid JSON.
-        """
-        self.xblock.lti_1p3_tool_public_key = ''
-        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
-        self.xblock.save()
-
-        jwt = create_jwt(self.key, {})
-        request = make_request(
-            urllib.parse.urlencode({
-                "grant_type": "client_credentials",
-                "client_assertion_type": "something",
-                "client_assertion": jwt,
-                "scope": "",
-            }),
-            'POST'
-        )
-        request.content_type = 'application/x-www-form-urlencoded'
-
-        res = Mock()
-        res.status_code = 200
-        res.text = b'this is not a valid json'
-        request_func.return_value = res
-
-        response = self.xblock.lti_1p3_access_token(request)
+        response_mock = Mock()
+        response_mock.status_code = 200
+        response_mock.text = b'this is not a valid json'
+        request.return_value = response_mock
+        response = self.xblock.lti_1p3_access_token(self.request)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json_body, {'error': 'invalid_client'})

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1538,8 +1538,7 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
     @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
     def test_access_token_using_keyset_url(self, load_jwks_from_url):
         """
-        Test request with valid JWT, using the provider's keyset URL
-        instead of a public key.
+        Test request with valid JWT, using the provider's keyset URL instead of a public key.
         """
         self.xblock.lti_1p3_tool_public_key = ''
         self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
@@ -1564,3 +1563,123 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
         response = self.xblock.lti_1p3_access_token(request)
         load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
         self.assertEqual(response.status_code, 200)
+
+    @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
+    def test_access_token_using_keyset_url_with_empty_keys(self, load_jwks_from_url):
+        """
+        Test request with valid JWT, where the provider's keyset URL returns an empty list of keys.
+        """
+        self.xblock.lti_1p3_tool_public_key = ''
+        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
+        self.xblock.save()
+
+        jwt = create_jwt(self.key, {})
+        request = make_request(
+            urllib.parse.urlencode({
+                "grant_type": "client_credentials",
+                "client_assertion_type": "something",
+                "client_assertion": jwt,
+                "scope": "",
+            }),
+            'POST'
+        )
+        request.content_type = 'application/x-www-form-urlencoded'
+
+        jwks = KEYS()
+        jwks._keys = []  # pylint: disable=protected-access
+        load_jwks_from_url.return_value = jwks
+
+        response = self.xblock.lti_1p3_access_token(request)
+        load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json_body, {'error': 'invalid_client'})
+
+    @patch('lti_consumer.lti_1p3.key_handlers.load_jwks_from_url')
+    def test_access_token_using_keyset_url_with_wrong_keys(self, load_jwks_from_url):
+        """
+        Test request with valid JWT, where the provider's keyset URL returns wrong keys.
+        """
+        self.xblock.lti_1p3_tool_public_key = ''
+        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
+        self.xblock.save()
+
+        jwt = create_jwt(self.key, {})
+        request = make_request(
+            urllib.parse.urlencode({
+                "grant_type": "client_credentials",
+                "client_assertion_type": "something",
+                "client_assertion": jwt,
+                "scope": "",
+            }),
+            'POST'
+        )
+        request.content_type = 'application/x-www-form-urlencoded'
+
+        rsa_key = RSA.generate(2048)
+        key = RSAKey(key=rsa_key, kid='2')
+
+        jwks = KEYS()
+        jwks._keys = [key]  # pylint: disable=protected-access
+        load_jwks_from_url.return_value = jwks
+
+        response = self.xblock.lti_1p3_access_token(request)
+        load_jwks_from_url.assert_called_once_with('http://tool.example/keyset')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json_body, {'error': 'invalid_client'})
+
+    @patch('jwkest.jwk.request')
+    def test_access_token_using_keyset_url_that_fails(self, request_func):
+        """
+        Test request with valid JWT, where the provider's keyset URL request fails.
+        """
+        self.xblock.lti_1p3_tool_public_key = ''
+        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
+        self.xblock.save()
+
+        jwt = create_jwt(self.key, {})
+        request = make_request(
+            urllib.parse.urlencode({
+                "grant_type": "client_credentials",
+                "client_assertion_type": "something",
+                "client_assertion": jwt,
+                "scope": "",
+            }),
+            'POST'
+        )
+        request.content_type = 'application/x-www-form-urlencoded'
+
+        request_func.side_effect = Exception('request fails')
+
+        response = self.xblock.lti_1p3_access_token(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json_body, {'error': 'invalid_client'})
+
+    @patch('jwkest.jwk.request')
+    def test_access_token_using_keyset_url_with_invalid_contents(self, request_func):
+        """
+        Test request with valid JWT, where the provider's keyset URL doesn't return valid JSON.
+        """
+        self.xblock.lti_1p3_tool_public_key = ''
+        self.xblock.lti_1p3_tool_keyset_url = 'http://tool.example/keyset'
+        self.xblock.save()
+
+        jwt = create_jwt(self.key, {})
+        request = make_request(
+            urllib.parse.urlencode({
+                "grant_type": "client_credentials",
+                "client_assertion_type": "something",
+                "client_assertion": jwt,
+                "scope": "",
+            }),
+            'POST'
+        )
+        request.content_type = 'application/x-www-form-urlencoded'
+
+        res = Mock()
+        res.status_code = 200
+        res.text = b'this is not a valid json'
+        request_func.return_value = res
+
+        response = self.xblock.lti_1p3_access_token(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json_body, {'error': 'invalid_client'})

--- a/lti_consumer/tests/unit/test_utils.py
+++ b/lti_consumer/tests/unit/test_utils.py
@@ -3,6 +3,7 @@ Utility functions used within unit tests
 """
 
 from unittest.mock import Mock
+import urllib
 from webob import Request
 from workbench.runtime import WorkbenchRuntime
 from xblock.fields import ScopeIds
@@ -50,6 +51,21 @@ def make_request(body, method='POST'):
     request.method = 'POST'
     request.body = body.encode('utf-8')
     request.method = method
+    return request
+
+
+def make_jwt_request(token, **overrides):
+    """
+    Builds a Request with a JWT body.
+    """
+    body = {
+        "grant_type": "client_credentials",
+        "client_assertion_type": "something",
+        "client_assertion": token,
+        "scope": "",
+    }
+    request = make_request(urllib.parse.urlencode({**body, **overrides}), 'POST')
+    request.content_type = 'application/x-www-form-urlencoded'
     return request
 
 

--- a/lti_consumer/translations/en/LC_MESSAGES/text.po
+++ b/lti_consumer/translations/en/LC_MESSAGES/text.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-07 15:54-0300\n"
+"POT-Creation-Date: 2022-01-18 07:25-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,71 +38,92 @@ msgstr ""
 msgid "Invalid token signature."
 msgstr ""
 
-#: lti_xblock.py:131
+#: lti_xblock.py:126
 msgid "No valid user id found in endpoint URL"
 msgstr ""
 
-#: lti_xblock.py:237
+#: lti_xblock.py:232
 msgid "Display Name"
 msgstr ""
 
-#: lti_xblock.py:239
+#: lti_xblock.py:234
 msgid ""
 "Enter the name that students see for this component. Analytics reports may "
 "also use the display name to identify this component."
 msgstr ""
 
-#: lti_xblock.py:243
+#: lti_xblock.py:238
 msgid "LTI Consumer"
 msgstr ""
 
-#: lti_xblock.py:246
+#: lti_xblock.py:241
 msgid "LTI Application Information"
 msgstr ""
 
-#: lti_xblock.py:248
+#: lti_xblock.py:243
 msgid ""
 "Enter a description of the third party application. If requesting username "
 "and/or email, use this text box to inform users why their username and/or "
 "email will be forwarded to a third party application."
 msgstr ""
 
-#: lti_xblock.py:258
+#: lti_xblock.py:253
 msgid "LTI Version"
 msgstr ""
 
-#: lti_xblock.py:266
+#: lti_xblock.py:261
 msgid ""
 "Select the LTI version that your tool supports.<br />The XBlock LTI Consumer "
 "fully supports LTI 1.1.1, LTI 1.3 and LTI Advantage features."
 msgstr ""
 
-#: lti_xblock.py:272
+#: lti_xblock.py:267
 msgid "Tool Launch URL"
 msgstr ""
 
-#: lti_xblock.py:276
+#: lti_xblock.py:271
 msgid ""
 "Enter the LTI 1.3 Tool Launch URL. <br />This is the URL the LMS will use to "
 "launch the LTI Tool."
 msgstr ""
 
-#: lti_xblock.py:281
+#: lti_xblock.py:276
 msgid "Tool Initiate Login URL"
 msgstr ""
 
-#: lti_xblock.py:285
+#: lti_xblock.py:280
 msgid ""
 "Enter the LTI 1.3 Tool OIDC Authorization url (can also be called login or "
 "login initiation URL).<br />This is the URL the LMS will use to start a LTI "
 "authorization prior to doing the launch request."
 msgstr ""
 
-#: lti_xblock.py:291
+#: lti_xblock.py:287
+msgid "Tool Public Key Mode"
+msgstr ""
+
+#: lti_xblock.py:295
+msgid "Select how the tool's public key information will be specified."
+msgstr ""
+
+#: lti_xblock.py:299
+msgid "Tool Keyset URL"
+msgstr ""
+
+#: lti_xblock.py:303
+msgid ""
+"Enter the LTI 1.3 Tool's JWK keysets URL.<br />This link should retrieve a "
+"JSON file containing public keys and signature algorithm information, so "
+"that the LMS can check if the messages and launch requests received have the "
+"signature from the tool.<br /><b>This is not required when doing LTI 1.3 "
+"Launches without LTI Advantage nor Basic Outcomes requests.</b>"
+msgstr ""
+
+#: lti_xblock.py:313
 msgid "Tool Public Key"
 msgstr ""
 
-#: lti_xblock.py:296
+#: lti_xblock.py:318
 msgid ""
 "Enter the LTI 1.3 Tool's public key.<br />This is a string that starts with "
 "'-----BEGIN PUBLIC KEY-----' and is required so that the LMS can check if "
@@ -111,61 +132,61 @@ msgid ""
 "Advantage nor Basic Outcomes requests.</b>"
 msgstr ""
 
-#: lti_xblock.py:306
+#: lti_xblock.py:328
 msgid "Enable LTI NRPS"
 msgstr ""
 
-#: lti_xblock.py:307
+#: lti_xblock.py:329
 msgid "Enable LTI Names and Role Provisioning Services."
 msgstr ""
 
-#: lti_xblock.py:314
+#: lti_xblock.py:336
 msgid "LTI 1.3 Block Client ID - DEPRECATED"
 msgstr ""
 
-#: lti_xblock.py:317
+#: lti_xblock.py:339
 msgid "DEPRECATED - This is now stored in the LtiConfiguration model."
 msgstr ""
 
-#: lti_xblock.py:320
+#: lti_xblock.py:342
 msgid "LTI 1.3 Block Key - DEPRECATED"
 msgstr ""
 
-#: lti_xblock.py:327
+#: lti_xblock.py:349
 msgid "Deep linking"
 msgstr ""
 
-#: lti_xblock.py:328
+#: lti_xblock.py:350
 msgid "Select True if you want to enable LTI Advantage Deep Linking."
 msgstr ""
 
-#: lti_xblock.py:333
+#: lti_xblock.py:355
 msgid "Deep Linking Launch URL"
 msgstr ""
 
-#: lti_xblock.py:337
+#: lti_xblock.py:359
 msgid ""
 "Enter the LTI Advantage Deep Linking Launch URL. If the tool does not "
 "specify one, use the same value as 'Tool Launch URL'."
 msgstr ""
 
-#: lti_xblock.py:342
+#: lti_xblock.py:364
 msgid "LTI Assignment and Grades Service"
 msgstr ""
 
-#: lti_xblock.py:344
+#: lti_xblock.py:366
 msgid "Disabled"
 msgstr ""
 
-#: lti_xblock.py:345
+#: lti_xblock.py:367
 msgid "Allow tools to submit grades only (declarative)"
 msgstr ""
 
-#: lti_xblock.py:346
+#: lti_xblock.py:368
 msgid "Allow tools to manage and submit grade (programmatic)"
 msgstr ""
 
-#: lti_xblock.py:351
+#: lti_xblock.py:373
 msgid ""
 "Enable the LTI-AGS service and select the functionality enabled for LTI "
 "tools. The 'declarative' mode (default) will provide a tool with a LineItem "
@@ -173,11 +194,11 @@ msgid ""
 "tools to manage, create and link the grades."
 msgstr ""
 
-#: lti_xblock.py:359
+#: lti_xblock.py:381
 msgid "LTI ID"
 msgstr ""
 
-#: lti_xblock.py:361
+#: lti_xblock.py:383
 #, python-brace-format
 msgid ""
 "Enter the LTI ID for the external LTI provider. This value must be the same "
@@ -186,11 +207,11 @@ msgid ""
 "documentation{anchor_close} for more details on this setting."
 msgstr ""
 
-#: lti_xblock.py:373
+#: lti_xblock.py:395
 msgid "LTI URL"
 msgstr ""
 
-#: lti_xblock.py:375
+#: lti_xblock.py:397
 #, python-brace-format
 msgid ""
 "Enter the URL of the external tool that this component launches. This "
@@ -199,11 +220,11 @@ msgid ""
 "this setting."
 msgstr ""
 
-#: lti_xblock.py:388
+#: lti_xblock.py:410
 msgid "Custom Parameters"
 msgstr ""
 
-#: lti_xblock.py:390
+#: lti_xblock.py:412
 #, python-brace-format
 msgid ""
 "Add the key/value pair for any custom parameters, such as the page your e-"
@@ -212,11 +233,11 @@ msgid ""
 "documentation{anchor_close} for more details on this setting."
 msgstr ""
 
-#: lti_xblock.py:400
+#: lti_xblock.py:422
 msgid "LTI Launch Target"
 msgstr ""
 
-#: lti_xblock.py:402
+#: lti_xblock.py:424
 msgid ""
 "Select Inline if you want the LTI content to open in an IFrame in the "
 "current page. Select Modal if you want the LTI content to open in a modal "
@@ -225,146 +246,146 @@ msgid ""
 "Tool is set to False."
 msgstr ""
 
-#: lti_xblock.py:416
+#: lti_xblock.py:438
 msgid "Button Text"
 msgstr ""
 
-#: lti_xblock.py:418
+#: lti_xblock.py:440
 msgid ""
 "Enter the text on the button used to launch the third party application. "
 "This setting is only used when Hide External Tool is set to False and LTI "
 "Launch Target is set to Modal or New Window."
 msgstr ""
 
-#: lti_xblock.py:426
+#: lti_xblock.py:448
 msgid "Inline Height"
 msgstr ""
 
-#: lti_xblock.py:428
+#: lti_xblock.py:450
 msgid ""
 "Enter the desired pixel height of the iframe which will contain the LTI "
 "tool. This setting is only used when Hide External Tool is set to False and "
 "LTI Launch Target is set to Inline."
 msgstr ""
 
-#: lti_xblock.py:436
+#: lti_xblock.py:458
 msgid "Modal Height"
 msgstr ""
 
-#: lti_xblock.py:438
+#: lti_xblock.py:460
 msgid ""
 "Enter the desired viewport percentage height of the modal overlay which will "
 "contain the LTI tool. This setting is only used when Hide External Tool is "
 "set to False and LTI Launch Target is set to Modal."
 msgstr ""
 
-#: lti_xblock.py:446
+#: lti_xblock.py:468
 msgid "Modal Width"
 msgstr ""
 
-#: lti_xblock.py:448
+#: lti_xblock.py:470
 msgid ""
 "Enter the desired viewport percentage width of the modal overlay which will "
 "contain the LTI tool. This setting is only used when Hide External Tool is "
 "set to False and LTI Launch Target is set to Modal."
 msgstr ""
 
-#: lti_xblock.py:456
+#: lti_xblock.py:478
 msgid "Scored"
 msgstr ""
 
-#: lti_xblock.py:457
+#: lti_xblock.py:479
 msgid ""
 "Select True if this component will receive a numerical score from the "
 "external LTI system."
 msgstr ""
 
-#: lti_xblock.py:464
+#: lti_xblock.py:486
 msgid ""
 "Enter the number of points possible for this component.  The default value "
 "is 1.0.  This setting is only used when Scored is set to True."
 msgstr ""
 
-#: lti_xblock.py:473
+#: lti_xblock.py:495
 msgid ""
 "The score kept in the xblock KVS -- duplicate of the published score in "
 "django DB"
 msgstr ""
 
-#: lti_xblock.py:478
+#: lti_xblock.py:500
 msgid "Comment as returned from grader, LTI2.0 spec"
 msgstr ""
 
-#: lti_xblock.py:483
+#: lti_xblock.py:505
 msgid "Hide External Tool"
 msgstr ""
 
-#: lti_xblock.py:485
+#: lti_xblock.py:507
 msgid ""
 "Select True if you want to use this component as a placeholder for syncing "
 "with an external grading  system rather than launch an external tool.  This "
 "setting hides the Launch button and any IFrames for this component."
 msgstr ""
 
-#: lti_xblock.py:493
+#: lti_xblock.py:515
 msgid "Accept grades past deadline"
 msgstr ""
 
-#: lti_xblock.py:494
+#: lti_xblock.py:516
 msgid ""
 "Select True to allow third party systems to post grades past the deadline."
 msgstr ""
 
-#: lti_xblock.py:502
+#: lti_xblock.py:524
 msgid "Request user's username"
 msgstr ""
 
 #. Translators: This is used to request the user's username for a third party service.
-#: lti_xblock.py:504
+#: lti_xblock.py:526
 msgid "Select True to request the user's username."
 msgstr ""
 
-#: lti_xblock.py:509
+#: lti_xblock.py:531
 msgid "Request user's email"
 msgstr ""
 
 #. Translators: This is used to request the user's email for a third party service.
-#: lti_xblock.py:511
+#: lti_xblock.py:533
 msgid "Select True to request the user's email address."
 msgstr ""
 
-#: lti_xblock.py:516
+#: lti_xblock.py:538
 msgid "Send extra parameters"
 msgstr ""
 
-#: lti_xblock.py:517
+#: lti_xblock.py:539
 msgid ""
 "Select True to send the extra parameters, which might contain Personally "
 "Identifiable Information. The processors are site-wide, please consult the "
 "site administrator if you have any questions."
 msgstr ""
 
-#: lti_xblock.py:578
+#: lti_xblock.py:602
 msgid "Custom Parameters must be a list"
 msgstr ""
 
-#: lti_xblock.py:717
+#: lti_xblock.py:712
 msgid ""
 "Could not parse LTI passport: {lti_passport!r}. Should be \"id:key:secret\" "
 "string."
 msgstr ""
 
-#: lti_xblock.py:733 lti_xblock.py:749
+#: lti_xblock.py:728 lti_xblock.py:744
 msgid "Could not get user id for current request"
 msgstr ""
 
-#: lti_xblock.py:854
+#: lti_xblock.py:849
 msgid ""
 "Could not parse custom parameter: {custom_parameter!r}. Should be \"x=y\" "
 "string."
 msgstr ""
 
-#: lti_xblock.py:1299
+#: lti_xblock.py:1304
 msgid "[LTI]: Real user not found against anon_id: {}"
 msgstr ""
 


### PR DESCRIPTION
This adds support for specifying a provider's keyset URL in the LTI consumer XBlock.

### Testing

1. Have a functioning koa or lilac devstack
2. Setup a LTI 1.3 provider that's able to access the devstack (i.e. via tunneling or provider self-hosting)
2. Install the LTI Consumer XBlock as per the instructions in the Readme, checking out this branch
3. Via the Studio, add an Unit containing an LTI Consumer block.
4. Open the XBlock edit dialog, and change the LTI Version to 1.3.
5. Verify that there's a new option to choose between using a Public Key and a Keyset URL.
6. Select Keyset URL, and fill the Launch URL, Login URL, Access Token URL and Keyset URL to the ones from the provider chosen at step 2.
7. Register the endpoints given by the LTI Consumer XBlock at the Studio preview with the provider.
7. Publish the Unit, and verify it launches successfully from the learning app.