### PR TITLE
[BB-6371] Backport fix for LTI 1.3 "target_link_uri"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,17 +318,13 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
-3.4.1 - 2022-02-01
+2.10.2 - 2022-06-15
 ------------------
 
 * Fix the target_link_uri parameter on OIDC login preflight url parameter so it matches 
   claim message definition of the field.
   See docs at https://www.imsglobal.org/spec/lti/v1p3#target-link-uri
-
-3.4.0 - 2022-01-31
-------------------
-
-* Fix the version number by bumping it up to 3.4.0
+* The fix was cherry-picked and added from `this commit on Version 3.4.1 <https://github.com/openedx/xblock-lti-consumer/commit/4629192807d31dd9d19144fbd71c9d50b2da7da5>`_.
 
 2.10.1 - 2021-06-09
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,18 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
+3.4.1 - 2022-02-01
+------------------
+
+* Fix the target_link_uri parameter on OIDC login preflight url parameter so it matches 
+  claim message definition of the field.
+  See docs at https://www.imsglobal.org/spec/lti/v1p3#target-link-uri
+
+3.4.0 - 2022-01-31
+------------------
+
+* Fix the version number by bumping it up to 3.4.0
+
 2.10.1 - 2021-06-09
 -------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -3,3 +3,4 @@ Runtime will load the XBlock class from here.
 """
 from .lti_xblock import LtiConsumerXBlock
 from .apps import LTIConsumerApp
+__version__ = '3.4.1'

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -3,4 +3,5 @@ Runtime will load the XBlock class from here.
 """
 from .lti_xblock import LtiConsumerXBlock
 from .apps import LTIConsumerApp
-__version__ = '3.4.1'
+
+__version__ = '2.10.2'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -91,7 +91,6 @@ def get_lti_1p3_launch_info(config_id=None, block=None):
 
     if lti_consumer.dl is not None:
         deep_linking_launch_url = lti_consumer.prepare_preflight_url(
-            callback_url=get_lms_lti_launch_link(),
             hint=lti_config.location,
             lti_hint="deep_linking_launch"
         )
@@ -138,7 +137,6 @@ def get_lti_1p3_launch_start_url(config_id=None, block=None, deep_link_launch=Fa
 
     # Prepare and return OIDC flow start url
     return lti_consumer.prepare_preflight_url(
-        callback_url=get_lms_lti_launch_link(),
         hint=hint,
         lti_hint=lti_hint
     )

--- a/lti_consumer/lti_1p3/README.md
+++ b/lti_consumer/lti_1p3/README.md
@@ -84,9 +84,7 @@ def lti_preflight_request(request):
     The platform needs to know the tool OIDC endpoint.
     """
     lti_consumer = _get_lti1p3_consumer()
-    context = lti_consumer.prepare_preflight_url(
-        callback_url=get_lms_lti_launch_link()
-    )
+    context = lti_consumer.prepare_preflight_url()
 
     # This template should render a simple redirection to the URL
     # provided by the context through the `oidc_url` key above.

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -90,7 +90,6 @@ class LtiConsumer1p3:
 
     def prepare_preflight_url(
             self,
-            callback_url,
             hint="hint",
             lti_hint="lti_hint"
     ):
@@ -102,7 +101,7 @@ class LtiConsumer1p3:
             "iss": self.iss,
             "client_id": self.client_id,
             "lti_deployment_id": self.deployment_id,
-            "target_link_uri": callback_url,
+            "target_link_uri": self.launch_url,
             "login_hint": hint,
             "lti_message_hint": lti_hint
         }

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -149,7 +149,6 @@ class TestLti1p3Consumer(TestCase):
         Check if preflight request is properly formed and has all required keys.
         """
         preflight_request_data = self.lti_consumer.prepare_preflight_url(
-            callback_url=LAUNCH_URL,
             hint="test-hint",
             lti_hint="test-lti-hint"
         )

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -69,7 +69,6 @@ def load_block_as_anonymous_user(location):
             student_data=None,
             course_id=location.course_key,
             track_function=None,
-            xqueue_callback_url_prefix="",
             request_token="",
         )
 


### PR DESCRIPTION
### Description

The latest LTI Consumer XBlock version (2.10.1) compatible with Lilac, and installed by default has a bug in its LTI 1.3 implementation. It sends the login URL of the Platform for the `target_link_uri` parameter in the preflight URL. The fix was added to the version 3.4.1. However this cannot be used with Lilac as 2.11 introduced changes that are compatible only from Maple onwards.

This PR cherry picks the fix from the 3.4.1 release and applies it onto version 2.10.1 and makes the bugfix available for Lilac users.

### Testing instructions

1. Configure a LTI 1.3 in a Lilac instance. Use https://saltire.lti.app/tool for testing.
2. Publish the unit with the XBLock and open it on LMS
3. Open the Network tab and check the preflight URL and its parameters (filtering for saltire will be useful)
4. Notice that the value for `target_link_uri` contains the domain of the instance and **not** Saltire.
5. Install the PR branch of LTI Consumer XBlock using `pip` in the instance and restart the LMS
6. Visit the same page in the LMS and and check the preflight request and the `target_link_uri` parameter. 
7. Verify that the `target_link_uri` is changes and points to the Saltire's URL.

### Screenshots

#### Default - Version 2.10.1

![before_backport](https://user-images.githubusercontent.com/383862/173992102-c244b229-e633-4dd8-be12-74fc01ab69ac.png)

#### After applying the fix

![backported](https://user-images.githubusercontent.com/383862/173992151-20eafda4-0694-4a78-a14a-f0bd2e7a460b.png)

