### PR TITLE
[BB-6232] feat: backport target link url fix to v3.4.0 without breaking on Maple

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -367,6 +367,18 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
+3.4.1 - 2022-02-01
+------------------
+
+* Fix the target_link_uri parameter on OIDC login preflight url parameter so it matches 
+  claim message definition of the field.
+  See docs at https://www.imsglobal.org/spec/lti/v1p3#target-link-uri
+
+3.4.0 - 2022-01-31
+------------------
+
+* Fix the version number by bumping it up to 3.4.0
+
 3.3.0 - 2022-01-20
 -------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '3.4.0'
+__version__ = '3.4.1'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -93,7 +93,6 @@ def get_lti_1p3_launch_info(config_id=None, block=None):
 
     if lti_consumer.dl is not None:
         deep_linking_launch_url = lti_consumer.prepare_preflight_url(
-            callback_url=get_lms_lti_launch_link(),
             hint=lti_config.location,
             lti_hint="deep_linking_launch"
         )
@@ -140,7 +139,6 @@ def get_lti_1p3_launch_start_url(config_id=None, block=None, deep_link_launch=Fa
 
     # Prepare and return OIDC flow start url
     return lti_consumer.prepare_preflight_url(
-        callback_url=get_lms_lti_launch_link(),
         hint=hint,
         lti_hint=lti_hint
     )

--- a/lti_consumer/lti_1p3/README.md
+++ b/lti_consumer/lti_1p3/README.md
@@ -84,9 +84,7 @@ def lti_preflight_request(request):
     The platform needs to know the tool OIDC endpoint.
     """
     lti_consumer = _get_lti1p3_consumer()
-    context = lti_consumer.prepare_preflight_url(
-        callback_url=get_lms_lti_launch_link()
-    )
+    context = lti_consumer.prepare_preflight_url()
 
     # This template should render a simple redirection to the URL
     # provided by the context through the `oidc_url` key above.

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -90,7 +90,6 @@ class LtiConsumer1p3:
 
     def prepare_preflight_url(
             self,
-            callback_url,
             hint="hint",
             lti_hint="lti_hint"
     ):
@@ -102,7 +101,7 @@ class LtiConsumer1p3:
             "iss": self.iss,
             "client_id": self.client_id,
             "lti_deployment_id": self.deployment_id,
-            "target_link_uri": callback_url,
+            "target_link_uri": self.launch_url,
             "login_hint": hint,
             "lti_message_hint": lti_hint
         }

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -149,7 +149,6 @@ class TestLti1p3Consumer(TestCase):
         Check if preflight request is properly formed and has all required keys.
         """
         preflight_request_data = self.lti_consumer.prepare_preflight_url(
-            callback_url=LAUNCH_URL,
             hint="test-hint",
             lti_hint="test-lti-hint"
         )

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -60,7 +60,6 @@ def load_block_as_anonymous_user(location):
             student_data=None,
             course_id=location.course_key,
             track_function=None,
-            xqueue_callback_url_prefix="",
             request_token="",
         )
 

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -60,6 +60,7 @@ def load_block_as_anonymous_user(location):
             student_data=None,
             course_id=location.course_key,
             track_function=None,
+            xqueue_callback_url_prefix="",
             request_token="",
         )
 


### PR DESCRIPTION
### Description

UQ are running Maple and also needed a fix from openedx#227. It turned out that 3.4.1 and above are not compatible with Maple, due to [this change](https://github.com/openedx/xblock-lti-consumer/pull/227/files#diff-dd1a635f81cbda5f3da563729ddb1768f21fc6b704ca8d1c166365475f22bf0bL63) in openedx#227.

Because v3.4.0 appeared to work with Maple, we decided to use it for UQ. Then we cherry-picked the fix from 3.4.1 - dd9822c, and reverted the breaking change - b7bcc1f.

### Testing

Has been tested by the client in their environment.